### PR TITLE
Update Dockerfile: include a JSONSchema validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN go get github.com/onsi/ginkgo/ginkgo \
   github.com/EngineerBetter/yml2env \
   gopkg.in/EngineerBetter/stopover.v2 \
   gopkg.in/EngineerBetter/stopover.v1 \
+  github.com/santhosh-tekuri/jsonschema/cmd/jv \
   && mv /go/bin/stopover.v1 /go/bin/stopover
 
 # Install gometalinter


### PR DESCRIPTION
$currentproject is adding early pipeline tests for ops file correctness/completeness - using JSONSchema (https://json-schema.org) seems like a reasonable way to achieve this.

The `jv` tool was chosen on the basis of it (a) being a single binary (b) providing a CLI tool and (c) being actively developed, against the current JSONSchema draft.

PLSCANHASMERGE?